### PR TITLE
Typo RESONACE -> RESONANCE

### DIFF
--- a/MOD/default-preset.ttl
+++ b/MOD/default-preset.ttl
@@ -9,7 +9,7 @@
 		lv2:symbol "ATTACK" ;
 		pset:value 0.5
 	] , [
-		lv2:symbol "RESONACE" ;
+		lv2:symbol "RESONANCE" ;
 		pset:value 0.5
 	] , [
 		lv2:symbol "TONE" ;

--- a/MOD/gx_voodoo.ttl
+++ b/MOD/gx_voodoo.ttl
@@ -98,8 +98,8 @@ All other trademarks are the property of their respective holders.
         a lv2:InputPort ,
             lv2:ControlPort ;
         lv2:index 3 ;
-        lv2:symbol "RESONACE" ;
-        lv2:name "RESONACE" ;
+        lv2:symbol "RESONANCE" ;
+        lv2:name "RESONANCE" ;
         lv2:default 0.5 ;
         lv2:minimum 0.0 ;
         lv2:maximum 1.0 ;

--- a/MOD/modgui.ttl
+++ b/MOD/modgui.ttl
@@ -20,8 +20,8 @@
             lv2:name "ATTACK" ;
         ] , [
             lv2:index 1 ;
-            lv2:symbol "RESONACE" ;
-            lv2:name "RESONACE" ;
+            lv2:symbol "RESONANCE" ;
+            lv2:name "RESONANCE" ;
         ] , [
             lv2:index 2 ;
             lv2:symbol "TONE" ;

--- a/dsp/voodoo.cc
+++ b/dsp/voodoo.cc
@@ -380,7 +380,7 @@ void Dsp::connect(uint32_t port,void* data)
 	case ATTACK: 
 		fslider1_ = (float*)data; // , 0.5, 0.0, 1.0, 0.01 
 		break;
-	case RESONACE: 
+	case RESONANCE: 
 		fslider0_ = (float*)data; // , 0.5, 0.0, 1.0, 0.01 
 		break;
 	case TONE: 
@@ -413,7 +413,7 @@ void Dsp::del_instance(PluginLV2 *p)
 typedef enum
 {
    ATTACK, 
-   RESONACE, 
+   RESONANCE, 
    TONE, 
    VOLUME,
 } PortIndex;

--- a/gui/gx_voodoo_ui.c
+++ b/gui/gx_voodoo_ui.c
@@ -120,7 +120,7 @@ static LV2UI_Handle instantiate(const LV2UI_Descriptor*   descriptor,
 
     ui->adj[1] = gtk_adjustment_new( 0.5, 0.0, 1.0, 0.01, 0.01*10.0, 0);
     ui->knob[1] = gtk_knob_new_with_adjustment(GTK_ADJUSTMENT(ui->adj[1]));
-    ui->label[1] = gtk_label_new("RESONACE");
+    ui->label[1] = gtk_label_new("RESONANCE");
     ui->vkbox[1] = gtk_vbox_new(FALSE, 0);
 
     gtk_widget_modify_fg (ui->label[1], GTK_STATE_NORMAL, &color);
@@ -134,7 +134,7 @@ static LV2UI_Handle instantiate(const LV2UI_Descriptor*   descriptor,
     gtk_box_pack_start(GTK_BOX(ui->vkbox[1]), ui->label[1], FALSE, FALSE, 0);
     ui->args[1] = (struct gx_args*) malloc(sizeof(struct gx_args));
     ui->args[1]->ui = ui;
-    ui->args[1]->port_index = (int)RESONACE;
+    ui->args[1]->port_index = (int)RESONANCE;
     g_signal_connect(G_OBJECT(ui->adj[1]), "value-changed",
           G_CALLBACK(ref_value_changed),(gpointer*)ui->args[1]);
 

--- a/plugin/gx_voodoo.h
+++ b/plugin/gx_voodoo.h
@@ -33,7 +33,7 @@ typedef enum
    EFFECTS_OUTPUT,
    EFFECTS_INPUT,
    ATTACK, 
-   RESONACE, 
+   RESONANCE, 
    TONE, 
    VOLUME,
 } PortIndex;

--- a/plugin/gx_voodoo.ttl
+++ b/plugin/gx_voodoo.ttl
@@ -84,8 +84,8 @@ rdfs:comment """
         a lv2:InputPort ,
             lv2:ControlPort ;
         lv2:index 3 ;
-        lv2:symbol "RESONACE" ;
-        lv2:name "RESONACE" ;
+        lv2:symbol "RESONANCE" ;
+        lv2:name "RESONANCE" ;
         lv2:default 0.5 ;
         lv2:minimum 0.0 ;
         lv2:maximum 1.0 ;


### PR DESCRIPTION
Unless it was on purpose (playing with the words in some way I didn't figured out), it looks a typo to me.
Please note that I didn't build it with this change so I'm not 100% sure it doesn't break anything.

I hope that helps.
Best wishes to you and yours for this new year's time.
